### PR TITLE
Clean up files from previous builds

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -9,6 +9,9 @@ ARCHIVE_NAME = "freetds-patched"
 
 puts "-----> FreeTDS building in #{BUILD_DIR}"
 
+puts "-----> Removing any previously cached FreeTDS"
+puts `find {CACHE_DIR} -type d -maxdepth 1 -name "freetds-[0-9]\.*" -exec rm -rv {} +`
+
 puts "-----> Fetching & Extracting FreeTDS"
 puts `mkdir -p #{CACHE_DIR}`
 puts `curl ftp://ftp.freetds.org/pub/freetds/stable/#{ARCHIVE_NAME}.tar.gz -o - | tar -xz -C #{CACHE_DIR} -f -`


### PR DESCRIPTION
Update the `compile` script to remove any freetds directories left in the `CACHE_DIR` by previous builds, as the rest of the script cannot handle multiple versions being present. This will also take care of cleaning up old versions when there is a new version of freetds released.

Long term, it would be preferable to clean up the files at the end of each build, but this won't fix problems which have already been caused by these leftover files.